### PR TITLE
output assays order to respect 'modes' order

### DIFF
--- a/R/scNMT.R
+++ b/R/scNMT.R
@@ -152,7 +152,7 @@ scNMT <-
     )
     names(modes_list) <- gsub("scnmt_", "", names(modes_list))
 
-    eh_experiments <- ExperimentList(modes_list)
+    eh_experiments <- ExperimentList(modes_list)[resultModes]
 
     ess_names <- c("colData", "metadata", "sampleMap")
 


### PR DESCRIPTION
This avoids confusion if assay names are used to query from ExperimentHub and assay indices used with the resulting MAE object.

Example
```r
scnmtseq <- scNMT(dataType = 'mouse_gastrulation', modes = c( "met_p300",
"acc_p300", "acc_CTCF", "acc_DHS"), dry.run = FALSE)

names(experiments(scnmtseq))

## currently
#> "acc_CTCF" "acc_DHS"  "acc_p300" "met_p300"
## proposed (same as queried)
#> "met_p300", "acc_p300", "acc_CTCF", "acc_DHS"

```
