### PR TITLE
citeseq fixing

### DIFF
--- a/R/CITEseq.R
+++ b/R/CITEseq.R
@@ -53,11 +53,13 @@
                                             names(explist)[assIdx[2]]),
                                         dimslist[assIdx][[2]][2]), 
                                     colnames(explist[[assIdx[2]]])))
+            rownames(m1) <- rownames(explist[[assIdx[[1]]]])
         } else {
             colnames(m1) <- paste0(rep(gsub("scADT|scHTO|scRNA","", 
                                             names(explist)[assIdx[1]]),
                                         dimslist[assIdx][[1]][2]), 
                                     colnames(explist[[assIdx[1]]]))
+            rownames(m1) <- rownames(explist[[assIdx[[1]]]])
         }
         return(m1)
     }
@@ -66,28 +68,11 @@
     {
         
         map <- DataFrame(assay=assayId,
-                        #primary=gsub("_\\w+", "", colnames(mat1)), 
                         primary=colnames(mat1),
                         colname=colnames(mat1), 
                         condition=gsub("_\\w+", "", colnames(mat1)))
         return(map)
     }
-    
-    # .buildColDat <- function(ll)
-    # {
-    #     if(all(names(ll)[grep("CTCL|CTRL", names(ll))] %in% names(ll)))
-    #     {
-    #         cd <- data.frame(row.names=c("CTCL", "CTRL"), 
-    #                    condition=c("Cutaneous T-cell Limphoma", "Control"))
-    #     } else if(!isEmpty(grep("CTCL", names(ll)))) {
-    #         cd <- data.frame(row.names=c("CTCL"), 
-    #                           condition=c("Cutaneous T-cell Limphoma"))
-    #     } else if(!isEmpty(grep("CTRL", names(ll)))) {
-    #         cd <- data.frame(row.names=c("CTRL"), 
-    #                           condition=c("Control"))
-    #     }
-    #     return(cd)
-    # }
     
     ll <- ess_list$experiments
     ll <- lapply(ll, function(x) 

--- a/vignettes/CITEseq.Rmd
+++ b/vignettes/CITEseq.Rmd
@@ -112,11 +112,12 @@ scADT data as `altExp`s.
 ```{r message=FALSE}
 sce <- CITEseq(DataType="cord_blood", modes="*", dry.run=FALSE, version="1.0.0",
               DataClass="SingleCellExperiment")
+sce
 ```
 
 # Session Info
 
-```{r}
+```{r, tidy=TRUE}
 sessionInfo()
 ```
 

--- a/vignettes/ECCITEseq.Rmd
+++ b/vignettes/ECCITEseq.Rmd
@@ -153,11 +153,12 @@ scADT data as `altExp`s.
 ```{r message=FALSE}
 sce <- CITEseq(DataType="peripheral_blood", modes="*", dry.run=FALSE, 
                version="1.0.0", DataClass="SingleCellExperiment")
+sce
 ```
 
 # Session Info
 
-```{r}
+```{r, tidy=TRUE}
 sessionInfo()
 ```
 

--- a/vignettes/seqFISH.Rmd
+++ b/vignettes/seqFISH.Rmd
@@ -159,7 +159,7 @@ mae
 
 # Session Info
 
-```{r}
+```{r, tidy=TRUE}
 sessionInfo()
 ```
 


### PR DESCRIPTION
- fixing rownames in ECCITEseq ADT and HTO matrices.
- minor improvements in seqfish, citeseq and ecciteseq vignettes