### PR TITLE
Minor updates

### DIFF
--- a/R/SCoPE2.R
+++ b/R/SCoPE2.R
@@ -87,7 +87,7 @@ SCoPE2 <- function(DataType = "macrophage_differentiation",
 
     ## Rename assays with project
     names(ess_list[["experiments"]]) <- 
-        paste0("macroph_diff_", names(ess_list[["experiments"]]))
+        paste0(names(ess_list[["experiments"]]))
     ## Construct and return the MAE object
     MultiAssayExperiment(experiments = ess_list[["experiments"]],
                          colData = cd)

--- a/R/SCoPE2.R
+++ b/R/SCoPE2.R
@@ -85,9 +85,6 @@ SCoPE2 <- function(DataType = "macrophage_differentiation",
     cd <- .mergeLowColData(ess_list[["experiments"]])
     colnames(cd)[which(colnames(cd) == "Batch")] <- "batch_Chromium"
 
-    ## Rename assays with project
-    names(ess_list[["experiments"]]) <- 
-        paste0(names(ess_list[["experiments"]]))
     ## Construct and return the MAE object
     MultiAssayExperiment(experiments = ess_list[["experiments"]],
                          colData = cd)

--- a/R/SCoPE2.R
+++ b/R/SCoPE2.R
@@ -87,7 +87,7 @@ SCoPE2 <- function(DataType = "macrophage_differentiation",
 
     ## Rename assays with project
     names(ess_list[["experiments"]]) <- 
-        paste0("macrophage_", names(ess_list[["experiments"]]))
+        paste0("macroph_diff_", names(ess_list[["experiments"]]))
     ## Construct and return the MAE object
     MultiAssayExperiment(experiments = ess_list[["experiments"]],
                          colData = cd)

--- a/vignettes/SCoPE2.Rmd
+++ b/vignettes/SCoPE2.Rmd
@@ -93,7 +93,7 @@ For more information on the protocol, see @Specht2020-jm.
 Only version `1.0.0` is currently available.
 
 The `macrophage_differentiation` data set in this package contains two
-assays: `macroph_diff_rna` and `macroph_diff_protein`. 
+assays: `rna` and `protein`. 
 
 ### Cell annotation
 
@@ -115,7 +115,7 @@ colData(scope2)
 You can extract and check the transcriptomic data through subsetting:
 
 ```{r}
-scope2[["macroph_diff_rna"]]
+scope2[["rna"]]
 ```
 
 The data is rather large and is therefore stored on-disk using the 
@@ -123,7 +123,7 @@ HDF5 backend. You can verify this by looking at the assay data matrix.
 Note that the counts are UMI counts.
 
 ```{r}
-assay(scope2[["macroph_diff_rna"]])[1:5, 1:5]
+assay(scope2[["rna"]])[1:5, 1:5]
 ```
 
 ### Proteomic data 
@@ -136,7 +136,7 @@ information about the data processing is available in
 transcriptomic data:
 
 ```{r}
-scope2[["macroph_diff_protein"]]
+scope2[["protein"]]
 ```
 
 In this case, the protein data have reasonable size and are loaded
@@ -145,7 +145,7 @@ decided to not use the traditional `logcounts` because MS proteomics
 measures intensities rather than counts as opposed to scRNA-Seq. 
 
 ```{r}
-assay(scope2[["macroph_diff_protein"]])[1:5, 1:5]
+assay(scope2[["protein"]])[1:5, 1:5]
 ```
 
 # sessionInfo

--- a/vignettes/SCoPE2.Rmd
+++ b/vignettes/SCoPE2.Rmd
@@ -11,7 +11,10 @@ output:
 Package: SingleCellMultiModal
 bibliography: ../inst/REFERENCES.bib
 ---
-    
+
+This vignette will guide you through how accessing and manipulating 
+the SCoPE2 data sets available from the `SingleCellMultimodal` package.
+ 
 # Installation
     
 ```{r,eval=FALSE}
@@ -56,7 +59,7 @@ Currently, only the `macrophage_differentiation` is available.
 
 ## Retrieving data
 
-You can use retrieve the actual data from `ExperimentHub` by setting 
+You can retrieve the actual data from `ExperimentHub` by setting 
 `dry.run = FALSE`. This example retrieves the complete data set 
 (transcriptome and proteome) for the `macrophage_differentiation` 
 project:
@@ -72,10 +75,10 @@ scope2
 
 This data set has been acquired by the Slavov Lab (@Specht2020-jm). 
 It contains single-cell proteomics and single-cell 
-RNA sequencing data for macrophages and monocytes. The object of the 
-research that lead to generate this data is to understand whether 
+RNA sequencing data for macrophages and monocytes. The objective of the 
+research that led to generate the data is to understand whether 
 homogeneous monocytes differentiate in the absence of cytokines to
-macrophage with homogeneous or heterogeneous profiles. The transcriptomic and 
+macrophages with homogeneous or heterogeneous profiles. The transcriptomic and 
 proteomic acquisitions are conducted on two separate subset of similar 
 cells (same experimental design). The cell type of the samples are known only 
 for the **proteomics** data. The proteomics data was retrieved from 
@@ -90,7 +93,7 @@ For more information on the protocol, see @Specht2020-jm.
 Only version `1.0.0` is currently available.
 
 The `macrophage_differentiation` data set in this package contains two
-assays: `macrophage_rna` and `macrophage_protein`. 
+assays: `macroph_diff_rna` and `macroph_diff_protein`. 
 
 ### Cell annotation
 
@@ -112,7 +115,7 @@ colData(scope2)
 You can extract and check the transcriptomic data through subsetting:
 
 ```{r}
-scope2[["rna"]]
+scope2[["macroph_diff_rna"]]
 ```
 
 The data is rather large and is therefore stored on-disk using the 
@@ -120,19 +123,20 @@ HDF5 backend. You can verify this by looking at the assay data matrix.
 Note that the counts are UMI counts.
 
 ```{r}
-assay(scope2[["rna"]])[1:5, 1:5]
+assay(scope2[["macroph_diff_rna"]])[1:5, 1:5]
 ```
 
 ### Proteomic data 
 
 The `protein` assay contains MS-based proteomic data. 
 The data have been passed sample and feature quality control, 
-normalized, log transformed, imputed and batch corrected. See 
-reference for more details about data processing. You can extract the
-proteomic data similarly to the transcriptomic data:
+normalized, log transformed, imputed and batch corrected. Detailed 
+information about the data processing is available in 
+[another vignette](https://uclouvain-cbio.github.io/SCP.replication/articles/SCoPE2.html). You can extract the proteomic data similarly to the 
+transcriptomic data:
 
 ```{r}
-scope2[["protein"]]
+scope2[["macroph_diff_protein"]]
 ```
 
 In this case, the protein data have reasonable size and are loaded
@@ -141,7 +145,7 @@ decided to not use the traditional `logcounts` because MS proteomics
 measures intensities rather than counts as opposed to scRNA-Seq. 
 
 ```{r}
-assay(scope2[["protein"]])[1:5, 1:5]
+assay(scope2[["macroph_diff_protein"]])[1:5, 1:5]
 ```
 
 # sessionInfo


### PR DESCRIPTION
Hi Marcel @LiNk-NY ,

This is a very small PR to change 2 things:

- The assays in the `macrophage_differentiation` project (SCoPE2) were called `macrophage_protein` and `macrophage_rna`. Laurent pointed out to me that this can be confusing because monocyte data are also present in the assays. I renamed the assays using the project abbreviation `macroph_diff_protein` and `macroph_diff_rna`.
- I adapted the vignette with the new assay names and fixed some typos.