### PR TITLE
fixing DataFrame conversion for spatialData in seqFISH

### DIFF
--- a/R/seqFISH.R
+++ b/R/seqFISH.R
@@ -98,7 +98,7 @@ seqFISH <-
         colData=modes_list$seqFISH_Labels,
         assays=S4Vectors::SimpleList(
             counts=as.matrix(modes_list$seqFISH_Counts)),
-        spatialData=modes_list$seqFISH_Coordinates)
+        spatialData=DataFrame(modes_list$seqFISH_Coordinates))
     mae <- MultiAssayExperiment::MultiAssayExperiment(
         experiments=list("seqFISH"=se, "scRNAseq"=sce))
     return(mae)


### PR DESCRIPTION
based on the latest version of SpatialExperiment (v. 1.1.700)

fixing https://github.com/waldronlab/SingleCellMultiModal/issues/39