### PR TITLE
ontomap should include function_name and DataType

### DIFF
--- a/inst/extdata/ontomap.tsv
+++ b/inst/extdata/ontomap.tsv
@@ -1,33 +1,33 @@
 DataType	function_name	original_column_name	original_cell_name	ontology_ID	ontology_cell_name
-macrophage_differentiation_protein	SCoPE2	celltype	Macrophage	CL:0000235	macrophage
-macrophage_differentiation_protein	SCoPE2	celltype	Monocyte	CLO:0009465	U-937 cell
-mouse_gastrulation	scNMT	lineage	Epiblast	NA	NA
-mouse_gastrulation	scNMT	lineage	Mesoderm	NA	NA
-mouse_gastrulation	scNMT	lineage	Primitive_Streak	NA	NA
-mouse_gastrulation	scNMT	lineage	Ectoderm	NA	NA
-mouse_gastrulation	scNMT	lineage	Endoderm	NA	NA
-mouse_gastrulation	scNMT	lineage	ExE_ectoderm	NA	NA
-mouse_gastrulation	scNMT	lineage	Visceral_endoderm	NA	NA
-mouse_gastrulation	scNMT	lineage	Primitive_endoderm	NA	NA
-mouse_visual_cortex	seqFISH	class	Glutamatergic Neuron	NA	NA
-mouse_visual_cortex	seqFISH	class	GABA-ergic Neuron	NA	NA
-mouse_visual_cortex	seqFISH	class	Oligodendrocyte.3	NA	NA
-mouse_visual_cortex	seqFISH	class	Endothelial Cell	NA	NA
-mouse_visual_cortex	seqFISH	class	Astrocyte	NA	NA
-mouse_visual_cortex	seqFISH	class	Oligodendrocyte.2	NA	NA
-mouse_visual_cortex	seqFISH	class	Microglia	NA	NA
-mouse_visual_cortex	seqFISH	class	Oligodendrocyte.1	NA	NA
-pbmc_10x	scMultiome	celltype	naive CD4 T cells	NA	NA
-pbmc_10x	scMultiome	celltype	memory CD4 T cells	NA	NA
-pbmc_10x	scMultiome	celltype	non-classical monocytes	NA	NA
-pbmc_10x	scMultiome	celltype	naive CD8 T cells	NA	NA
-pbmc_10x	scMultiome	celltype	CD56 (bright) NK cells	NA	NA
-pbmc_10x	scMultiome	celltype	classical monocytes	NA	NA
-pbmc_10x	scMultiome	celltype	effector CD8 T cells	NA	NA
-pbmc_10x	scMultiome	celltype	myeloid DC	NA	NA
-pbmc_10x	scMultiome	celltype	intermediate monocytes	NA	NA
-pbmc_10x	scMultiome	celltype	memory B cells	NA	NA
-pbmc_10x	scMultiome	celltype	MAIT T cells	NA	NA
-pbmc_10x	scMultiome	celltype	CD56 (dim) NK cells	NA	NA
-pbmc_10x	scMultiome	celltype	naive B cells	NA	NA
-pbmc_10x	scMultiome	celltype	plasmacytoid DC	NA	NA
+1	macrophage_differentiation	SCoPE2	celltype	Macrophage	CL:0000235	macrophage
+2	macrophage_differentiation	SCoPE2	celltype	Monocyte	CLO:0009465	U-937 cell
+3	mouse_gastrulation	scNMT	lineage	Epiblast	NA	NA
+4	mouse_gastrulation	scNMT	lineage	Mesoderm	NA	NA
+5	mouse_gastrulation	scNMT	lineage	Primitive_Streak	NA	NA
+6	mouse_gastrulation	scNMT	lineage	Ectoderm	NA	NA
+7	mouse_gastrulation	scNMT	lineage	Endoderm	NA	NA
+8	mouse_gastrulation	scNMT	lineage	ExE_ectoderm	NA	NA
+9	mouse_gastrulation	scNMT	lineage	Visceral_endoderm	NA	NA
+10	mouse_gastrulation	scNMT	lineage	Primitive_endoderm	NA	NA
+11	mouse_visual_cortex	seqFISH	class	Glutamatergic Neuron	NA	NA
+12	mouse_visual_cortex	seqFISH	class	GABA-ergic Neuron	NA	NA
+13	mouse_visual_cortex	seqFISH	class	Oligodendrocyte.3	NA	NA
+14	mouse_visual_cortex	seqFISH	class	Endothelial Cell	NA	NA
+15	mouse_visual_cortex	seqFISH	class	Astrocyte	NA	NA
+16	mouse_visual_cortex	seqFISH	class	Oligodendrocyte.2	NA	NA
+17	mouse_visual_cortex	seqFISH	class	Microglia	NA	NA
+18	mouse_visual_cortex	seqFISH	class	Oligodendrocyte.1	NA	NA
+19	pbmc_10x	scMultiome	celltype	naive CD4 T cells	NA	NA
+20	pbmc_10x	scMultiome	celltype	memory CD4 T cells	NA	NA
+21	pbmc_10x	scMultiome	celltype	non-classical monocytes	NA	NA
+22	pbmc_10x	scMultiome	celltype	naive CD8 T cells	NA	NA
+23	pbmc_10x	scMultiome	celltype	CD56 (bright) NK cells	NA	NA
+24	pbmc_10x	scMultiome	celltype	classical monocytes	NA	NA
+25	pbmc_10x	scMultiome	celltype	effector CD8 T cells	NA	NA
+26	pbmc_10x	scMultiome	celltype	myeloid DC	NA	NA
+27	pbmc_10x	scMultiome	celltype	intermediate monocytes	NA	NA
+28	pbmc_10x	scMultiome	celltype	memory B cells	NA	NA
+29	pbmc_10x	scMultiome	celltype	MAIT T cells	NA	NA
+30	pbmc_10x	scMultiome	celltype	CD56 (dim) NK cells	NA	NA
+31	pbmc_10x	scMultiome	celltype	naive B cells	NA	NA
+32	pbmc_10x	scMultiome	celltype	plasmacytoid DC	NA	NA

--- a/inst/extdata/ontomap.tsv
+++ b/inst/extdata/ontomap.tsv
@@ -1,41 +1,33 @@
-dataset_name	original_column_name	original_cell_name	ontology_ID	ontology_cell_name	function_name
-macrophage_differentiation_protein_SCoPE2	celltype	Macrophage	CL:0000235	macrophage	SCoPE2
-macrophage_differentiation_protein_SCoPE2	celltype	Monocyte	CLO:0009465	U-937 cell	SCoPE2
-mouse_gastrulation_scNMT	lineage	Epiblast	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	Mesoderm	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	Primitive_Streak	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	Ectoderm	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	Endoderm	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	ExE_ectoderm	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	Visceral_endoderm	NA	NA	scNMT
-mouse_gastrulation_scNMT	lineage	Primitive_endoderm	NA	NA	scNMT
-mouse_visual_cortex_scRNAseq	class	Astrocyte	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	GABA-ergic Neuron	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	Endothelial Cell	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	Glutamatergic Neuron	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	Microglia	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.3	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.2	NA	NA	CITEseq
-mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.1	NA	NA	CITEseq
-mouse_visual_cortex_seqFISH	class	Glutamatergic Neuron	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	GABA-ergic Neuron	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	Oligodendrocyte.3	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	Endothelial Cell	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	Astrocyte	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	Oligodendrocyte.2	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	Microglia	NA	NA	seqFISH
-mouse_visual_cortex_seqFISH	class	Oligodendrocyte.1	NA	NA	seqFISH
-pbmc_10x_multiome	celltype	naive CD4 T cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	memory CD4 T cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	non-classical monocytes	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	naive CD8 T cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	CD56 (bright) NK cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	classical monocytes	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	effector CD8 T cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	myeloid DC	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	intermediate monocytes	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	memory B cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	MAIT T cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	CD56 (dim) NK cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	naive B cells	NA	NA	scMultiome
-pbmc_10x_multiome	celltype	plasmacytoid DC	NA	NA	scMultiome
+DataType	function_name	original_column_name	original_cell_name	ontology_ID	ontology_cell_name
+macrophage_differentiation_protein	SCoPE2	celltype	Macrophage	CL:0000235	macrophage
+macrophage_differentiation_protein	SCoPE2	celltype	Monocyte	CLO:0009465	U-937 cell
+mouse_gastrulation	scNMT	lineage	Epiblast	NA	NA
+mouse_gastrulation	scNMT	lineage	Mesoderm	NA	NA
+mouse_gastrulation	scNMT	lineage	Primitive_Streak	NA	NA
+mouse_gastrulation	scNMT	lineage	Ectoderm	NA	NA
+mouse_gastrulation	scNMT	lineage	Endoderm	NA	NA
+mouse_gastrulation	scNMT	lineage	ExE_ectoderm	NA	NA
+mouse_gastrulation	scNMT	lineage	Visceral_endoderm	NA	NA
+mouse_gastrulation	scNMT	lineage	Primitive_endoderm	NA	NA
+mouse_visual_cortex	seqFISH	class	Glutamatergic Neuron	NA	NA
+mouse_visual_cortex	seqFISH	class	GABA-ergic Neuron	NA	NA
+mouse_visual_cortex	seqFISH	class	Oligodendrocyte.3	NA	NA
+mouse_visual_cortex	seqFISH	class	Endothelial Cell	NA	NA
+mouse_visual_cortex	seqFISH	class	Astrocyte	NA	NA
+mouse_visual_cortex	seqFISH	class	Oligodendrocyte.2	NA	NA
+mouse_visual_cortex	seqFISH	class	Microglia	NA	NA
+mouse_visual_cortex	seqFISH	class	Oligodendrocyte.1	NA	NA
+pbmc_10x	scMultiome	celltype	naive CD4 T cells	NA	NA
+pbmc_10x	scMultiome	celltype	memory CD4 T cells	NA	NA
+pbmc_10x	scMultiome	celltype	non-classical monocytes	NA	NA
+pbmc_10x	scMultiome	celltype	naive CD8 T cells	NA	NA
+pbmc_10x	scMultiome	celltype	CD56 (bright) NK cells	NA	NA
+pbmc_10x	scMultiome	celltype	classical monocytes	NA	NA
+pbmc_10x	scMultiome	celltype	effector CD8 T cells	NA	NA
+pbmc_10x	scMultiome	celltype	myeloid DC	NA	NA
+pbmc_10x	scMultiome	celltype	intermediate monocytes	NA	NA
+pbmc_10x	scMultiome	celltype	memory B cells	NA	NA
+pbmc_10x	scMultiome	celltype	MAIT T cells	NA	NA
+pbmc_10x	scMultiome	celltype	CD56 (dim) NK cells	NA	NA
+pbmc_10x	scMultiome	celltype	naive B cells	NA	NA
+pbmc_10x	scMultiome	celltype	plasmacytoid DC	NA	NA

--- a/inst/extdata/ontomap.tsv
+++ b/inst/extdata/ontomap.tsv
@@ -1,41 +1,41 @@
-dataset_name	original_column_name	original_cell_name	ontology_ID	ontology_cell_name
-mouse_gastrulation_scNMT	lineage	Epiblast	NA	NA
-mouse_gastrulation_scNMT	lineage	Mesoderm	NA	NA
-mouse_gastrulation_scNMT	lineage	Primitive_Streak	NA	NA
-mouse_gastrulation_scNMT	lineage	Ectoderm	NA	NA
-mouse_gastrulation_scNMT	lineage	Endoderm	NA	NA
-mouse_gastrulation_scNMT	lineage	ExE_ectoderm	NA	NA
-mouse_gastrulation_scNMT	lineage	Visceral_endoderm	NA	NA
-mouse_gastrulation_scNMT	lineage	Primitive_endoderm	NA	NA
-pbmc_10x_multiome	celltype	naive CD4 T cells	NA	NA
-pbmc_10x_multiome	celltype	memory CD4 T cells	NA	NA
-pbmc_10x_multiome	celltype	non-classical monocytes	NA	NA
-pbmc_10x_multiome	celltype	naive CD8 T cells	NA	NA
-pbmc_10x_multiome	celltype	CD56 (bright) NK cells	NA	NA
-pbmc_10x_multiome	celltype	classical monocytes	NA	NA
-pbmc_10x_multiome	celltype	effector CD8 T cells	NA	NA
-pbmc_10x_multiome	celltype	myeloid DC	NA	NA
-pbmc_10x_multiome	celltype	intermediate monocytes	NA	NA
-pbmc_10x_multiome	celltype	memory B cells	NA	NA
-pbmc_10x_multiome	celltype	MAIT T cells	NA	NA
-pbmc_10x_multiome	celltype	CD56 (dim) NK cells	NA	NA
-pbmc_10x_multiome	celltype	naive B cells	NA	NA
-pbmc_10x_multiome	celltype	plasmacytoid DC	NA	NA
-macrophage_differentiation_protein_SCoPE2	celltype	Macrophage	CL:0000235	macrophage
-macrophage_differentiation_protein_SCoPE2	celltype	Monocyte	CLO:0009465	U-937 cell
-mouse_visual_cortex_seqFISH	class	Glutamatergic Neuron	NA	NA
-mouse_visual_cortex_seqFISH	class	GABA-ergic Neuron	NA	NA
-mouse_visual_cortex_seqFISH	class	Oligodendrocyte.3	NA	NA
-mouse_visual_cortex_seqFISH	class	Endothelial Cell	NA	NA
-mouse_visual_cortex_seqFISH	class	Astrocyte	NA	NA
-mouse_visual_cortex_seqFISH	class	Oligodendrocyte.2	NA	NA
-mouse_visual_cortex_seqFISH	class	Microglia	NA	NA
-mouse_visual_cortex_seqFISH	class	Oligodendrocyte.1	NA	NA
-mouse_visual_cortex_scRNAseq	class	Astrocyte	NA	NA
-mouse_visual_cortex_scRNAseq	class	GABA-ergic Neuron	NA	NA
-mouse_visual_cortex_scRNAseq	class	Endothelial Cell	NA	NA
-mouse_visual_cortex_scRNAseq	class	Glutamatergic Neuron	NA	NA
-mouse_visual_cortex_scRNAseq	class	Microglia	NA	NA
-mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.3	NA	NA
-mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.2	NA	NA
-mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.1	NA	NA
+dataset_name	original_column_name	original_cell_name	ontology_ID	ontology_cell_name	function_name
+macrophage_differentiation_protein_SCoPE2	celltype	Macrophage	CL:0000235	macrophage	SCoPE2
+macrophage_differentiation_protein_SCoPE2	celltype	Monocyte	CLO:0009465	U-937 cell	SCoPE2
+mouse_gastrulation_scNMT	lineage	Epiblast	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	Mesoderm	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	Primitive_Streak	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	Ectoderm	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	Endoderm	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	ExE_ectoderm	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	Visceral_endoderm	NA	NA	scNMT
+mouse_gastrulation_scNMT	lineage	Primitive_endoderm	NA	NA	scNMT
+mouse_visual_cortex_scRNAseq	class	Astrocyte	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	GABA-ergic Neuron	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	Endothelial Cell	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	Glutamatergic Neuron	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	Microglia	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.3	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.2	NA	NA	CITEseq
+mouse_visual_cortex_scRNAseq	class	Oligodendrocyte.1	NA	NA	CITEseq
+mouse_visual_cortex_seqFISH	class	Glutamatergic Neuron	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	GABA-ergic Neuron	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	Oligodendrocyte.3	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	Endothelial Cell	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	Astrocyte	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	Oligodendrocyte.2	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	Microglia	NA	NA	seqFISH
+mouse_visual_cortex_seqFISH	class	Oligodendrocyte.1	NA	NA	seqFISH
+pbmc_10x_multiome	celltype	naive CD4 T cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	memory CD4 T cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	non-classical monocytes	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	naive CD8 T cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	CD56 (bright) NK cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	classical monocytes	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	effector CD8 T cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	myeloid DC	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	intermediate monocytes	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	memory B cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	MAIT T cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	CD56 (dim) NK cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	naive B cells	NA	NA	scMultiome
+pbmc_10x_multiome	celltype	plasmacytoid DC	NA	NA	scMultiome

--- a/inst/scripts/ontomap_update.R
+++ b/inst/scripts/ontomap_update.R
@@ -1,0 +1,18 @@
+## read in
+onto <- readr::read_tsv("inst/extdata/ontomap.tsv")
+
+## modification
+onto <- as.data.frame(onto)
+onto[onto$DataType == "macrophage_differentiation_protein", "DataType"] <-
+    "macrophage_differentiation"
+
+## output checking
+stopifnot(
+    identical(length(unique(onto[["DataType"]])), 4L)
+)
+
+## writing
+write.table(
+    x = onto, file = "inst/extdata/ontomap.tsv",
+    quote = FALSE, sep = "\t", row.names = FALSE
+)


### PR DESCRIPTION
@drighelli 
Hi Dario, 
I think the map should have terms that are also in the package so that users can easily relate the code for particular function to the onto-mapping. For example, it should have a `function_name` column (added in the current PR) and also a `DataType` column that corresponds to the `DataType` argument in each of the functions, if possible. 
Can you take a look at the map and separate the `dataset_name` into those values? 
Can you also double check that the function name corresponds to the right annotation? (esp. for `CITEseq`, I may have gotten that one wrong).
You can read the map in with : 
```r
read.delim("inst/extdata/ontomap.tsv")
```
after checking the branch out. 
```sh
git branch -d drighelli-ontomap
git checkout -b drighelli-ontomap origin/drighelli-ontomap
```
PS. I used the same branch name but you may have to delete yours first (as above).
Thanks!

