### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,19 +3,18 @@ Package: SingleCellMultiModal
 Title: Integrating Multi-modal Single Cell Experiment datasets
 Version: 1.23.0
 Authors@R: c(
-    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu",
-        c("aut", "cre"), c(ORCID = "0000-0002-3242-0582")
-    ),
-    person("Ricard", "Argelaguet", , "ricard@ebi.ac.uk", "aut"),
-    person("Al", "Abadi", , , "ctb"),
-    person("Dario", "Righelli", , "dario.righelli@gmail.com", "aut"),
-    person("Christophe", "Vanderaa", ,
-        "christophe.vanderaa@uclouvain.be", "ctb"),
-    person("Kelly", "Eckenrode", , "kelly.eckenrode@sph.cuny.edu", "aut"),
-    person("Ludwig", "Geistlinger", ,
-        "ludwig_geistlinger@hms.harvard.edu", "aut"),
-    person("Levi", "Waldron", , "lwaldron.research@gmail.com", "aut")
-    )
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-3242-0582")),
+    person("Ricard", "Argelaguet", , "ricard@ebi.ac.uk", role = "aut"),
+    person("Al", "Abadi", role = "ctb"),
+    person("Dario", "Righelli", , "dario.righelli@gmail.com", role = "aut"),
+    person("Christophe", "Vanderaa", , "christophe.vanderaa@uclouvain.be", role = "ctb"),
+    person("Kelly", "Eckenrode", , "kelly.eckenrode@sph.cuny.edu", role = "aut"),
+    person("Ludwig", "Geistlinger", , "ludwig_geistlinger@hms.harvard.edu", role = "aut"),
+    person("Levi", "Waldron", , "lwaldron.research@gmail.com", role = "aut"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
+  )
 Description: SingleCellMultiModal is an ExperimentHub package
     that serves multiple datasets obtained from GEO and other sources and
     represents them as MultiAssayExperiment objects. We provide several


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616390780](https://github.com/waldronlab/repo-audits/actions/runs/23616390780)).